### PR TITLE
Fix position of board menu on show and hide.

### DIFF
--- a/app/js/bottomMenu.js
+++ b/app/js/bottomMenu.js
@@ -4,7 +4,7 @@ menu.onmousedown = () => setTimeout(menu.hide.bind(menu));
 
 menu.show = function () {
   this.style.opacity = 1;
-  this.style.bottom = 30;
+  this.style.bottom = `30px`;
 
   document.querySelector("#menuopen .container").style.transform =
     "rotateZ(180deg)";
@@ -12,7 +12,7 @@ menu.show = function () {
 
 menu.hide = function () {
   this.style.opacity = 0;
-  this.style.bottom = -this.clientHeight - 100;
+  this.style.bottom = `${-this.clientHeight - 100}px`;
 
   document.querySelector("#menuopen .container").style.transform =
     "rotateZ(0deg)";


### PR DESCRIPTION
The board menu was just hanging out in the upper right corner of the board. Even when invisible, it occluded the content underneath it, intercepting mouse clicks in that area. This positions and animates the board menu as it should be.

![board-menu-fix](https://user-images.githubusercontent.com/34490321/117506907-f99a9e80-af4b-11eb-9ab7-3de27fee1830.gif)
